### PR TITLE
Added a missing comma to action definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ import EasyActions from 'redux-easy-actions';
 export default EasyActions({
    ADD_TODO(type, text){
        return {type, text}
-   }
+   },
    DELETE_TODO(type, id){
        return {type, id}
    }


### PR DESCRIPTION
Nothing fancy. Just added a missing comma from your examples.
