### PR TITLE
Automatically inject type into return object rather than setting it in the action creator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ First write action creators, and import the EasyActions decorator:
 import EasyActions from 'redux-easy-actions';
 
 const { Actions, Constansts } = EasyActions({
-   ADD_TODO(type, text){
-       return {type, text}
+   ADD_TODO(text){
+       return {text}
    },
-   DELETE_TODO(type, id){
-       return {type, id}
+   DELETE_TODO(id){
+       return {id}
    }
 })
 
@@ -95,7 +95,7 @@ export { Actions as Actions }
 export { Constants as Constants }
 
 ```
-> Important: As first argument always passed action type, this happens automatically no need to pass it manually. 
+> Important: First argument is automatically injected into the return object, therefore, no need to pass parameter.
 
 That's all! Actions are created. Next connect it to reducer:
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -66,11 +66,7 @@ function formatActions(_ref, action) {
     return {
         Constants: Object.assign(Constants, _defineProperty({}, action.name, action.name)),
         Actions: Object.assign(Actions, _defineProperty({}, action.name, function () {
-            for (var _len2 = arguments.length, args = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
-                args[_key2] = arguments[_key2];
-            }
-
-            return action.fn.apply(action, [action.name].concat(args));
+            return Object.assign({ type: action.name }, action.fn.apply(action, arguments));
         }))
     };
 }

--- a/src/core.js
+++ b/src/core.js
@@ -48,7 +48,12 @@ function formatActions({Constants, Actions}, action){
     }
     return {
         Constants: Object.assign(Constants, {[action.name]: action.name}),
-        Actions: Object.assign(Actions, {[action.name]: (...args) => {return action.fn(action.name, ...args)}})
+        Actions: Object.assign(Actions, {
+            [action.name]: (...args) => Object.assign(
+                { type: action.name },
+                action.fn(...args)
+            )
+        })
     }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -3,8 +3,8 @@ import assert from 'assert';
 
 describe('redux-easy-actions full class decorator tests', () => {
     const ItemActions = EasyActions({
-        ADD_ITEM(type, text){
-            return {type, text}
+        ADD_ITEM(text){
+            return {text}
         }
     })
     const {Actions, Constants} = ItemActions;


### PR DESCRIPTION
As per title, rather than having:
```js
const { Actions, Constansts } = EasyActions({
   ADD_TODO(type, text){
       return {type, text}
   },
   DELETE_TODO(type, id){
       return {type, id}
   }
});
```
We can make it more succinct and have:
```js
const { Actions, Constansts } = EasyActions({
   ADD_TODO: text => ({ text }),
   DELETE_TODO: id => ({ id })
});
```
Allowing us to focus on the payload and let EasyActions deal with all the typing.